### PR TITLE
Add full content field and test URL

### DIFF
--- a/pagefind-mcp.js
+++ b/pagefind-mcp.js
@@ -76,6 +76,7 @@ async function doSearch(query, limit = 20) {
       title: h.meta.title,
       url: `https://news.smol.ai${h.url}`,
       excerpt: h.excerpt,
+      content: h.raw_content, // larger snippet text
     })),
   };
 }

--- a/test/pagefind-mcp.test.js
+++ b/test/pagefind-mcp.test.js
@@ -37,6 +37,13 @@ test('search queries return textual results', async (t) => {
           expected.test(data.hits[0].excerpt.replace(/<[^>]+>/g, '')),
         `excerpt for ${term} should contain expected text`
       );
+      assert.ok(
+        typeof data.hits[0].content === 'string' && data.hits[0].content.length > 0,
+        `content for ${term} should exist`
+      );
+      // verify returned URL
+      const parsed = new URL(data.hits[0].url);
+      assert.ok(parsed.protocol.startsWith('http'), `url for ${term} should be valid`);
     }
   } finally {
     await client.close();


### PR DESCRIPTION
## Summary
- include `raw_content` in results as `content`
- verify the returned URL in tests without curl

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68405398f9e48324848b0c34952c975b