### PR TITLE
Add no-resources flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # pagefind-mcp
 An MCP server for searching static sites that are indexed with pagefind
+
+## Usage
+
+```
+npx pagefind-mcp [--no-resources]
+```
+
+The `--no-resources` flag skips pushing full page resources and instead returns
+short text content for each search hit.


### PR DESCRIPTION
## Summary
- add `--no-resources` flag to control resource pushing
- parse the requested page for short content when `--no-resources` is used
- push pages as resources otherwise
- document flag in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68405d6d47c48324bc1107e4302766f6