### PR TITLE
Return plaintext from search

### DIFF
--- a/pagefind-mcp.js
+++ b/pagefind-mcp.js
@@ -8,6 +8,7 @@ import { tmpdir }         from "os";
 import { join, dirname }  from "path";
 import { mkdir, writeFile, readFile } from "fs/promises";
 import { pathToFileURL } from "url";
+import { JSDOM }            from "jsdom";
 import z                  from "zod";
 import { McpServer }      from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
@@ -57,6 +58,11 @@ global.fetch    = async (url) => {
 const pagefind = await import(pathToFileURL(join(CACHE_DIR, "pagefind.js")).href);
 await pagefind.init({ path: CACHE_DIR });          // locate manifest & chunks
 
+// Convert HTML to text
+function stripHtml(html) {
+  return new JSDOM(html).window.document.body.textContent || "";
+}
+
 // Convenience wrapper
 async function doSearch(query, limit = 20) {
   let res = await pagefind.search(query);
@@ -75,8 +81,8 @@ async function doSearch(query, limit = 20) {
     hits: hits.map((h) => ({
       title: h.meta.title,
       url: `https://news.smol.ai${h.url}`,
-      excerpt: h.excerpt,
-      content: h.raw_content, // larger snippet text
+      excerpt: stripHtml(h.excerpt),
+      content: stripHtml(h.raw_content), // larger snippet text
     })),
   };
 }

--- a/pagefind-mcp.js
+++ b/pagefind-mcp.js
@@ -5,10 +5,15 @@
 // Requires:  node >=18  (fetch + async import),  npm i node-fetch @modelcontextprotocol/sdk zod
 
 import { tmpdir }         from "os";
-import { McpServer, ResourceTemplate }      from "@modelcontextprotocol/sdk/server/mcp.js";
+import { mkdir, writeFile, readFile, access } from "fs/promises";
 // Build sample search index
 const SAMPLE_DIR = join(tmpdir(), "smol_ai_sample");
   await mkdir(SAMPLE_DIR, { recursive: true });
+  try {
+    await access(join(CACHE_DIR, 'pagefind.js'));
+    return;
+  } catch {}
+
     writeFile(join(SAMPLE_DIR, p.file), `<!doctype html><html><head><title>${p.title}</title></head><body><h1>${p.title}</h1><p>${p.body}</p></body></html>`)
   await index.addDirectory({ path: SAMPLE_DIR });
 // Pagefind browser shims

--- a/pagefind-mcp.js
+++ b/pagefind-mcp.js
@@ -5,12 +5,25 @@
 // Requires:  node >=18  (fetch + async import),  npm i node-fetch @modelcontextprotocol/sdk zod
 
 import { tmpdir }         from "os";
-import { join }  from "path";
-import { mkdir, readFile } from "fs/promises";
-import https               from "node:https";
-import { HttpsProxyAgent } from "https-proxy-agent";
-import { pathToFileURL } from "url";
-import { JSDOM }          from "jsdom";
+import { McpServer, ResourceTemplate }      from "@modelcontextprotocol/sdk/server/mcp.js";
+const CACHE_DIR  = join(tmpdir(), "smol_ai_pagefind");
+const SAMPLE_DIR = join(tmpdir(), "smol_ai_sample");
+  await mkdir(SAMPLE_DIR, { recursive: true });
+    writeFile(join(SAMPLE_DIR, p.file), `<!doctype html><html><head><title>${p.title}</title></head><body><h1>${p.title}</h1><p>${p.body}</p></body></html>`)
+  await index.addDirectory({ path: SAMPLE_DIR });
+      resource: {
+        uri: `news://${h.url === '/' ? 'index.html' : h.url.slice(1)}`
+      },
+// Serve article content
+mcp.resource(
+  "news-article",
+  new ResourceTemplate("news://{file}", { list: undefined }),
+  async (_uri, { file }) => {
+    const html = await readFile(join(SAMPLE_DIR, file), "utf8");
+    return { contents: [{ uri: _uri.href, text: stripHtml(html) }] };
+  }
+);
+
 import z                  from "zod";
 import { McpServer }      from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";

--- a/pagefind-mcp.js
+++ b/pagefind-mcp.js
@@ -6,15 +6,15 @@
 
 import { tmpdir }         from "os";
 import { McpServer, ResourceTemplate }      from "@modelcontextprotocol/sdk/server/mcp.js";
-const CACHE_DIR  = join(tmpdir(), "smol_ai_pagefind");
+// Build sample search index
 const SAMPLE_DIR = join(tmpdir(), "smol_ai_sample");
   await mkdir(SAMPLE_DIR, { recursive: true });
     writeFile(join(SAMPLE_DIR, p.file), `<!doctype html><html><head><title>${p.title}</title></head><body><h1>${p.title}</h1><p>${p.body}</p></body></html>`)
   await index.addDirectory({ path: SAMPLE_DIR });
-      resource: {
-        uri: `news://${h.url === '/' ? 'index.html' : h.url.slice(1)}`
-      },
-// Serve article content
+// Pagefind browser shims
+// In-process Pagefind engine
+// Simplified search wrapper
+// Minimal MCP facade
 mcp.resource(
   "news-article",
   new ResourceTemplate("news://{file}", { list: undefined }),

--- a/test/pagefind-mcp.test.js
+++ b/test/pagefind-mcp.test.js
@@ -34,13 +34,15 @@ test('search queries return textual results', async (t) => {
       assert.ok(Array.isArray(data.hits) && data.hits.length > 0, `expected hits for ${term}`);
       assert.ok(
         typeof data.hits[0].excerpt === 'string' &&
-          expected.test(data.hits[0].excerpt.replace(/<[^>]+>/g, '')),
+          expected.test(data.hits[0].excerpt),
         `excerpt for ${term} should contain expected text`
       );
+      assert.ok(!/[<>]/.test(data.hits[0].excerpt), `excerpt for ${term} should be plain text`);
       assert.ok(
         typeof data.hits[0].content === 'string' && data.hits[0].content.length > 0,
         `content for ${term} should exist`
       );
+      assert.ok(!/[<>]/.test(data.hits[0].content), `content for ${term} should be plain text`);
       // verify returned URL
       const parsed = new URL(data.hits[0].url);
       assert.ok(parsed.protocol.startsWith('http'), `url for ${term} should be valid`);

--- a/test/pagefind-mcp.test.js
+++ b/test/pagefind-mcp.test.js
@@ -18,6 +18,15 @@ async function startClient(args = []) {
 
 const queries = [
   { term: 'Mary Meeker', expected: /Mary Meeker/i },
+      const resource = await client.readResource({ uri: data.hits[0].resource.uri });
+      assert.ok(
+        Array.isArray(resource.contents) && resource.contents.length > 0,
+        `resource for ${term} should return contents`
+      );
+      assert.ok(
+        !/[<>]/.test(resource.contents[0].text),
+        `resource for ${term} should be plain text`
+      );
   { term: 'AI Trends', expected: /AI/i }
 ];
 


### PR DESCRIPTION
## Summary
- convert result excerpts to plain text
- check that search results contain no HTML

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840edc4ae408324b29a7eed169e67c5