### PR TITLE
Add bin field for npx usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "An MCP server for searching static sites that are indexed with pagefind",
   "main": "pagefind-mcp.js",
+  "bin": {
+    "pagefind-mcp": "./pagefind-mcp.js"
+  },
   "scripts": {
     "test": "node --test"
   },


### PR DESCRIPTION
## Summary
- expose CLI via `bin` entry to enable `npx pagefind-mcp`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840f002fd34832484265386e5e88cee